### PR TITLE
add meshgrid wrapper for quickly building ND in mem grids

### DIFF
--- a/aglio/coordinate_transformations.py
+++ b/aglio/coordinate_transformations.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import numpy as np
 
 from aglio.typing import all_numbers
@@ -114,7 +116,7 @@ def geosphere2cart(
     lat: all_numbers, lon: all_numbers, radius: all_numbers
 ) -> all_numbers:
     """
-    transformation from latitude, longitude to to cartesian
+    transformation from latitude, longitude to cartesian
 
     Parameters
     ----------
@@ -141,3 +143,44 @@ def geosphere2cart(
     theta = lon * np.pi / 180.0
 
     return sphere2cart(phi, theta, radius)
+
+
+def build_full_uniform_grid(
+    left_edge: List[float],
+    right_edge: List[float],
+    grid_shape: List[int],
+    indexing: Optional[str] = "ij",
+    copy: Optional[bool] = None,
+    sparse: Optional[bool] = None,
+):
+
+    """
+    build a ND grid in memory via np.meshgrid by specifying the bounds and size
+    of each dimension.
+
+    Parameters
+    ----------
+    left_edge : List[float]
+        the minimum values for each dimension
+    right_edge : List[float]
+        the maximum values for each dimension
+    grid_shape : List[int]
+        the number of grid points in each dimension
+
+    remaining parameters (indexing, copy, sparse) get passed to `np.meshgrid`.
+    Note that the default `indexing` here is 'ij' rather than 'xy'.
+
+    Returns
+    -------
+    tuple of ND arrays corresponding to the meshed variation in each dimension
+    """
+
+    dims_1d = []
+    ndim = len(grid_shape)
+    for idim in range(ndim):
+        le = left_edge[idim]
+        re = right_edge[idim]
+        n = grid_shape[idim]
+        dims_1d.append(np.linspace(le, re, n))
+
+    return np.meshgrid(*dims_1d, indexing=indexing, copy=copy, sparse=sparse)

--- a/aglio/coordinate_transformations.py
+++ b/aglio/coordinate_transformations.py
@@ -173,6 +173,15 @@ def build_full_uniform_grid(
     Returns
     -------
     tuple of ND arrays corresponding to the meshed variation in each dimension
+
+    Examples
+    --------
+
+    >>> from aglio.coordinate_transformations import build_full_uniform_grid
+    >>> import numpy as np
+    >>> # build a spherical coordinate grid
+    >>> r, theta, phi = build_full_uniform_grid([0., 0., 0.,], [1., np.pi, 2*np.pi], [10, 12, 14])
+    >>> r.shape # (10, 12, 14)
     """
 
     dims_1d = []

--- a/aglio/tests/test_coordinate_transformations.py
+++ b/aglio/tests/test_coordinate_transformations.py
@@ -3,6 +3,7 @@
 """Tests for `aglio` package."""
 
 import numpy as np
+import pytest
 
 import aglio
 import aglio.coordinate_transformations as yct
@@ -72,3 +73,18 @@ def test_to_cartesian():
     ds = aglio.open_dataset(vs_file)
     _ = ds.aglio.interpolate_to_uniform_cartesian(["dvs"])
     _ = ds.aglio.interpolate_to_uniform_cartesian(["dvs"], N=100)
+
+
+@pytest.mark.parametrize("nd", [2, 3])
+def test_build_full_uniform_grid(nd):
+
+    left_edge = [
+        0.0,
+    ] * nd
+    right_edge = [le + 1.0 for le in left_edge]
+    shp = (3,) * nd
+    coords = yct.build_full_uniform_grid(left_edge, right_edge, shp)
+    assert len(coords) == nd
+    assert coords[0].shape == shp
+    for c in coords:
+        assert c.shape == coords[0].shape


### PR DESCRIPTION
This adds a simple wrapper for `np.meshgrid` that let's you specify the left/right edges of a grid along with the desired grid shape. 