### PR TITLE
make tslearn an optional dependency

### DIFF
--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -18,7 +18,7 @@ jobs:
         python -m pip install --upgrade pip
     - name: Setup aglio
       run: |
-        python -m pip install -e .[dev]
+        python -m pip install -e .[dev,full]
     - name: Test with pytest
       run: pytest --cov=./ --cov-report=xml:coverage/coverage.xml
 

--- a/aglio/_utilities/dependencies.py
+++ b/aglio/_utilities/dependencies.py
@@ -25,6 +25,19 @@ class DependencyChecker:
                 self._has_yt = False
         return self._has_yt
 
+    _has_tslearn = None
+
+    @property
+    def has_tslearn(self):
+        if self._has_tslearn is None:
+            try:
+                import tslearn  # noqa: F401
+
+                self._has_tslearn = True
+            except ImportError:
+                self._has_tslearn = False
+        return self._has_tslearn
+
     def requires(self, module_name, func):
         def wrapper(*args, **kwargs):
             att_name = f"has_{module_name}"
@@ -37,3 +50,8 @@ class DependencyChecker:
 
 
 dependency_checker = DependencyChecker()
+
+
+class TimeSeriesKMeansDummy:
+    def __init__(self, *args, **kwargs):
+        raise ImportError("This functionality requires tslearn, please install.")

--- a/aglio/seismology/collections.py
+++ b/aglio/seismology/collections.py
@@ -3,10 +3,14 @@ from typing import Optional, Type
 import numpy as np
 from dask import compute, delayed
 from geopandas import GeoDataFrame, points_from_xy, sjoin
-from tslearn.clustering import TimeSeriesKMeans
 
 from aglio.mapping import BoundingPolies, default_crs
 from aglio.point_data import _gpd_df_from_lat_lon
+
+try:
+    from tslearn.clustering import TimeSeriesKMeans
+except ImportError:
+    from aglio._utilities.dependencies import TimeSeriesKMeansDummy as TimeSeriesKMeans
 
 
 class ProfileCollection:

--- a/aglio/tests/test_dependencies.py
+++ b/aglio/tests/test_dependencies.py
@@ -1,11 +1,12 @@
 import pytest
 
-from aglio._utilities.dependencies import dependency_checker
+from aglio._utilities.dependencies import TimeSeriesKMeansDummy, dependency_checker
 
 
 def test_attributes():
-    assert dependency_checker.has_yt is True
+    assert dependency_checker.has_yt
     assert dependency_checker.has_cartopy is False
+    assert dependency_checker.has_tslearn
 
 
 def test_decorator():
@@ -18,3 +19,8 @@ def test_decorator():
     missing_wrapped = dependency_checker.requires("not_a_module", temp_func)
     with pytest.raises(ImportError, match="This method requires not_a_module"):
         _ = missing_wrapped(2)
+
+
+def test_tslearn_dummy():
+    with pytest.raises(ImportError, match="This functionality requires tslearn"):
+        _ = TimeSeriesKMeansDummy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies=["netcdf4",
               "shapely>=2.0",
               "xarray",
               "scikit-learn",
-              "tslearn",
               "dask",
  ]
 
@@ -44,6 +43,7 @@ dev = [
 ]
 full = [
     "yt>4.1",
+    "tslearn",
 ]
 extra = [
     "yt>4.1",


### PR DESCRIPTION
tslearn comes with some big dependencies (i.e., numba) and aglio only uses it in one spot, this PR makes it an optional depedency.